### PR TITLE
Expose all errors to your app from webpack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,9 @@ function register(server, options, next) {
     webpack(options, function (err, _stats) {
         if (err) return next(err)
         var stats = _stats.toJson()
+        if(stats.errors.length > 0) {
+            return next(stats.errors[0])
+        }
         var paths = stats.assets.map(function (asset) {
             var _path = '/' + asset.name
             server.route({


### PR DESCRIPTION
Webpack does not return all errors in the first param of the callback. It passes some types errors in the stats object (for instance if a loader is not installed).

This PR exposes those back to your hapi app.

I chose to expose one at a time, this seems like the best/only way to do it "the hapi way" unless we pass a json string back and thats ugly/messy.
